### PR TITLE
Emitting event when the env is prompted

### DIFF
--- a/projects/common/src/lib/environment.service.ts
+++ b/projects/common/src/lib/environment.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Storage } from '@ionic/storage';
-import { ActionSheetController, Platform } from '@ionic/angular';
+import { ActionSheetController, Platform, Events } from '@ionic/angular';
 
 @Injectable()
 export class Environment {
@@ -19,7 +19,8 @@ export class Environment {
     private http: HttpClient,
     private storage: Storage,
     private actionSheetCtrl: ActionSheetController,
-    private platform: Platform
+    private platform: Platform,
+    private events: Events
   ) {}
 
   static config() {
@@ -57,6 +58,7 @@ export class Environment {
             if (storedEnvironment == null) {
               if (environments.length > 1) {
                 console.log('No saved environment detected, will prompt user for selection');
+                this.events.publish('ngx_common:environment_prompted');
                 this.showEnvironmentActionSheet(environments, json);
               } else {
                 const environment = environments[0];


### PR DESCRIPTION
Necesidad
--------------
En un proyecto de Capacitor es necesario ocultar la Splash Screen cuando la primera pantalla está ya visible para mejorar la experiencia de usuario, evitando así que el usuario vea una pantalla blanca mientras el webview carga.

Cuando la aplicación tiene varios entornos y se instala de cero, se pregunta al usuario que elija entorno de manera bloqueante, ya que hasta que el entorno no es escogido la app no navega a la pantalla inicial. Teniendo en cuenta esto, en un primer arranque con selección de entorno necesitamos conocer si el selector de entornos se ha mostrado para ocultar la splash screen.

Cambios
-------------- 
- Emisión de un evento cuando se va a mostrar el selector de entornos para que la aplicación pueda ocultar la splash screen.