### PR TITLE
Fix hardware back button

### DIFF
--- a/projects/common/package.json
+++ b/projects/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okode/ngx-common",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "peerDependencies": {
     "@angular/common": ">= 7.1.0",
     "@angular/core": ">= 7.1.0",

--- a/projects/common/src/lib/hardware-back-button.service.ts
+++ b/projects/common/src/lib/hardware-back-button.service.ts
@@ -47,10 +47,10 @@ export class HardwareBackButton {
       let overlay: any = document.querySelector(overlaySelector);
       if (overlay && overlay.getTop) { overlay = await overlay.getTop(); }
       if (overlay) {
-        if (overlay && overlay.backdropDismiss === true) { overlay.dismiss(); }
+        if (overlay.backdropDismiss === true) { overlay.dismiss(); }
         return;
       }
-      if (this.menuCtrl.isOpen()) {
+      if (await this.menuCtrl.isOpen()) {
         this.menuCtrl.close();
         return;
       }

--- a/projects/custom-palette/package.json
+++ b/projects/custom-palette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okode/ngx-custom-palette",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "peerDependencies": {
     "@angular/common": ">= 7.1.0",
     "@angular/core": ">= 7.1.0"


### PR DESCRIPTION
Hardware back button is only closing the menu overlay in the current version(1.5.13 and 1.6.2). This pull request fixes the problem and bumps the common and custom-palette projects version.