### PR TITLE
fix: MS-131 Wrong '@angular/compiler/src/core' import

### DIFF
--- a/projects/common/src/lib/common.module.ts
+++ b/projects/common/src/lib/common.module.ts
@@ -1,5 +1,4 @@
-import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { ModuleWithProviders } from '@angular/compiler/src/core';
+import { NgModule, APP_INITIALIZER, ModuleWithProviders } from '@angular/core';
 import { Environment } from './environment.service';
 import { Navigator } from './navigator.service';
 import { HardwareBackButton } from './hardware-back-button.service';


### PR DESCRIPTION
Existía un warning que aparecía al utilizar el plugin de ngx-common al referencias la ruta del código en un import.

Se ha modificado para utilizar el export que se proporciona en `@angular/core``

La tarea se ha solicitado en el siguiente ticket de Jira https://okode.atlassian.net/browse/MS-131