### PR TITLE
fix(OKD-44): Add default host if error.url has not one

### DIFF
--- a/projects/common/src/lib/sentry-error-handler.service.ts
+++ b/projects/common/src/lib/sentry-error-handler.service.ts
@@ -36,7 +36,7 @@ export class SentryErrorHandler extends ErrorHandler {
 
   static sendServerError(error: HttpErrorResponse) {
     Sentry.captureEvent({
-      message: `ServerError [${error.status}] ${new URL(error.url).pathname}`,
+      message: `ServerError [${error.status}] ${new URL(error.url, 'https://tempuri.org').pathname}`,
       level: Sentry.Severity.Warning,
       transaction: `[${error.status}] ${error.url}`,
       extra: { response: error }


### PR DESCRIPTION
This will solve TypeError if url is like '/path/example'